### PR TITLE
Updates to AIR instance for manifest support

### DIFF
--- a/iri/switch.py
+++ b/iri/switch.py
@@ -37,8 +37,6 @@ class Switch(Thread):
         logging.info("Starting IRI Switch instance %s" % name)
         self.name = name
         self.input = input
-        if isinstance(input, list):
-            self.input = " ".join(input)
         self.dataplane = dataplane
         self.killed = False
         self.instance = IriInstance(name, input, dataplane.send)


### PR DESCRIPTION
Support processing a group of files as a single yaml
chunk of input. A new aggregator class was added to AIR.
When add_content is called, if it is passed a list of
filenames, the contents of all those files is accumulated
and then processed as a single chunk of input.